### PR TITLE
protection from reflection

### DIFF
--- a/p4/sidecar-lite.p4
+++ b/p4/sidecar-lite.p4
@@ -682,6 +682,10 @@ control ingress(
         //
 
         mac.apply(hdr, egress);
+
+        if (ingress.port == egress.port) {
+            egress.drop = true;
+        }
     }
 }
 


### PR DESCRIPTION
A report from @luqmana follows.

> Been chatting with Levon about this but wanted to bring it to the wider group as well. Recently noticed some odd behaviour on my local network after deploying omicron w/ softnpu where unrelated devices on the LAN are seemingly losing packets here and there. Sor far we've discovered traffic is getting reflected from my helios box back to my router causing some MAC flapping.
> 
> An example of this happening with some innocuous broadcast/multicast traffic coming from my laptop (`192.168.1.4`/`0c:e4:41:e7:a9:bb`) and (understandably) also arriving at my helios box:
> 
> ```console
> $ pfexec tcpdump-bpf -i sc0_1 -ne -Q in host 192.168.1.94
> tcpdump-bpf: verbose output suppressed, use -v or -vv for full protocol decode
> listening on sc0_1, link-type EN10MB (Ethernet), capture size 262144 bytes
> 04:35:43.947824 0c:e4:41:e7:a9:bb > ff:ff:ff:ff:ff:ff, ethertype IPv4 (0x0800), length 86: 192.168.1.94.57621 > 192.168.1.255.57621: UDP, length 44
> 04:36:03.301009 0c:e4:41:e7:a9:bb > 01:00:5e:7f:ff:fa, ethertype IPv4 (0x0800), length 218: 192.168.1.94.51041 > 239.255.255.250.1900: UDP, length 176
> 04:36:04.301929 0c:e4:41:e7:a9:bb > 01:00:5e:7f:ff:fa, ethertype IPv4 (0x0800), length 218: 192.168.1.94.51041 > 239.255.255.250.1900: UDP, length 176
> 04:36:05.311859 0c:e4:41:e7:a9:bb > 01:00:5e:7f:ff:fa, ethertype IPv4 (0x0800), length 218: 192.168.1.94.51041 > 239.255.255.250.1900: UDP, length 176
> ```
> 
> But then those same packets get sent right back out from helios to the gateway/router (`9c:3d:cf:4c:b5:30`):
> 
> ```console
> $ pfexec tcpdump-bpf -i sc0_1 -ne -Q out host 192.168.1.94
> tcpdump-bpf: verbose output suppressed, use -v or -vv for full protocol decode
> listening on sc0_1, link-type EN10MB (Ethernet), capture size 262144 bytes
> 04:35:43.948126 0c:e4:41:e7:a9:bb > 9c:3d:cf:4c:b5:30, ethertype IPv4 (0x0800), length 86: 192.168.1.94.57621 > 192.168.1.255.57621: UDP, length 44
> 04:36:03.301218 0c:e4:41:e7:a9:bb > 9c:3d:cf:4c:b5:30, ethertype IPv4 (0x0800), length 218: 192.168.1.94.51041 > 239.255.255.250.1900: UDP, length 176
> 04:36:04.302223 0c:e4:41:e7:a9:bb > 9c:3d:cf:4c:b5:30, ethertype IPv4 (0x0800), length 218: 192.168.1.94.51041 > 239.255.255.250.1900: UDP, length 176
> 04:36:05.312145 0c:e4:41:e7:a9:bb > 9c:3d:cf:4c:b5:30, ethertype IPv4 (0x0800), length 218: 192.168.1.94.51041 > 239.255.255.250.1900: UDP, length 176
> ```
> 
> The destination MACs are getting rewritten to my router's somewhere before being sent out. But the source MACs are still my laptop's there so that would definitely confuse the router's MAC-to-port table. Which is exactly what I see happening on the router when I dump its MAC table: the laptop's MAC entry is flipping between the physical port connected to the helios box (incorrect) and the one bridged to the wireless AP (correct). In the brief moments when the entry is incorrect, unrelated unicast flows end up being incorrectly forwared to helios (where they get presumambly dropped I imagine).
> 
> I don't see this behaviour on an older checkout of omicron (e.g., `4970c71eda26b18387246839e81b722e7d9ecb74` does not have the same behaviour). Dendrite rev-wise that's `56f211202538ab370cec2fc6da5af532b10b0c7c` (bad) vs `231ad14027c01df2ce239b455220a90a24d4afc7` (good). The softnpu & sidecar-lite artifacts downloaded from CI remain the same though.
> 
> I do see one difference in the `scadm standalone dump-state` output.
> 
> Bad case (recent omicron):
> 
> ```
> pfexec /opt/oxide/softnpu/stuff/scadm --server /opt/oxide/softnpu/stuff/server --client /opt/oxide/softnpu/stuff/client standalone dump-state
> local v6:
> fe80::aae1:deff:fe01:701d
> fe80::aae1:deff:fe01:701c
> fd00:99::1
> local v4:
> router v6:
> fd00:1122:3344:101::/64 -> fe80::aae1:deff:fe00:1 (1)
> router v4:
> 0.0.0.0/0 -> 192.168.1.1 (2)
> resolver v4:
> 192.168.1.1 -> 9c:3d:cf:4c:b5:30
> resolver v6:
> fe80::aae1:deff:fe00:1 -> a8:e1:de:00:00:01
> nat v4:
> nat_v6:
> port_mac:
> icmp_v6:
> icmp_v4:
> proxy arp:
> 192.168.1.20/192.168.1.21: a8:e1:de:01:70:1d
> ```
> 
> Good case (older omicron):
> 
> ```
> pfexec /opt/oxide/softnpu/stuff/scadm --server /opt/oxide/softnpu/stuff/server --client /opt/oxide/softnpu/stuff/client standalone dump-state
> local v6:
> fd00:99::1
> fe80::aae1:deff:fe01:701d
> fe80::aae1:deff:fe01:701c
> local v4:
> router v6:
> fd00:1122:3344:101::/64 -> fe80::aae1:deff:fe00:1 (1)
> router v4:
> 0.0.0.0/0 -> 192.168.1.1 (2)
> resolver v4:
> 192.168.1.1 -> 9c:3d:cf:4c:b5:30
> resolver v6:
> fe80::aae1:deff:fe00:1 -> a8:e1:de:00:00:01
> nat v4:
> nat_v6:
> port_mac:
> 1: a8:40:25:f6:99:16
> 2: a8:40:25:f6:99:17
> icmp_v6:
> icmp_v4:
> proxy arp:
> 192.168.1.20/192.168.1.21: a8:e1:de:01:70:1d
> ```
> 
> The `port_mac` table (`ingress.mac.mac_rewrite`) is no longer populated. Most of those values get added as part of the `tools/scrimlet/softnpu-init.sh` script. I ran the steps in it manually and it looks like things start to go wrong after adding the default (v4) route to the "upstream gateway" (my router in this case):
> 
> ```
> # Configure upstream network gateway ARP entry
> z_swadm arp add "$GATEWAY_IP" "$GATEWAY_MAC" # GATEWAY_MAC=9c:3d:cf:4c:b5:30
> # Configure route to upstream gateway
> z_swadm route add 0.0.0.0/0 qsfp0/0 "$GATEWAY_IP" # GATEWAY_IP=192.168.1.1
> ```

We should not be reflecting packets back onto the network. This can currently happen if we have a route that matches the destination on the same port. This updates provides protection against this.