### PR TITLE
Zero out encap udp6 checksum on ingress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,8 @@ dependencies = [
  "p4-macro",
  "p4rs",
  "pnet",
+ "pnet_macros",
+ "pnet_macros_support",
  "tests",
  "usdt 0.3.5 (git+https://github.com/oxidecomputer/usdt)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "softnpu",
     "scadm",
 ]
+resolver = "2"
 
 [workspace.dependencies]
 p4rs = { git = "https://github.com/oxidecomputer/p4", branch = "main" }

--- a/p4/sidecar-lite.p4
+++ b/p4/sidecar-lite.p4
@@ -362,6 +362,7 @@ control nat_ingress(
         hdr.ox_external_tag.opt_len = 5w0;
         hdr.ox_external_tag.setValid();
 
+        /// TODO: this is broken so just set to zero for now.
         hdr.udp.checksum = csum.run({
             hdr.ipv6.src,
             hdr.ipv6.dst,
@@ -377,6 +378,7 @@ control nat_ingress(
             hdr.ox_external_tag.class,
             orig_l3_csum,
         });
+        hdr.udp.checksum = 16w0;
 
     }
 


### PR DESCRIPTION
The x4c/p4rs checksumming machinery is not working properly. Setting the outer udp6 checksum to zero is an allowable thing, so just do that for now. It also matches what we're doing in OPTE.