### PR TITLE
Correctly pass slot count during `add-route4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 [[package]]
 name = "p4"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=mod#e1d66d0cb412b08dfd906654051c0fdaace37d0d"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#b1007658f9638dfc60af75286ff5c108d6b2714c"
 dependencies = [
  "colored",
  "regex",
@@ -1421,7 +1421,7 @@ dependencies = [
 [[package]]
 name = "p4-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=mod#e1d66d0cb412b08dfd906654051c0fdaace37d0d"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#b1007658f9638dfc60af75286ff5c108d6b2714c"
 dependencies = [
  "p4",
  "p4-rust",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "p4-rust"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=mod#e1d66d0cb412b08dfd906654051c0fdaace37d0d"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#b1007658f9638dfc60af75286ff5c108d6b2714c"
 dependencies = [
  "p4",
  "prettyplease",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "p4rs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=mod#e1d66d0cb412b08dfd906654051c0fdaace37d0d"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#b1007658f9638dfc60af75286ff5c108d6b2714c"
 dependencies = [
  "bitvec",
  "colored",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "softnpu"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/softnpu?branch=nils_test#ed919c8ae1cadbab9501040585648e50ab52c2de"
+source = "git+https://github.com/oxidecomputer/softnpu?branch=main#dbab082dfa89da5db5ca2325c257089d2f130092"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "tests"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=mod#e1d66d0cb412b08dfd906654051c0fdaace37d0d"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#b1007658f9638dfc60af75286ff5c108d6b2714c"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/scadm/src/main.rs
+++ b/scadm/src/main.rs
@@ -329,9 +329,9 @@ async fn main() {
             let mut keyset_data: Vec<u8> = destination.octets().into();
             keyset_data.push(mask);
 
+            // Hardcoded slot count.
             let mut parameter_data = idx.to_le_bytes().to_vec();
-            // Hardcode a mask of 0
-            parameter_data.extend_from_slice(&0u16.to_le_bytes());
+            parameter_data.extend_from_slice(&1u8.to_le_bytes());
 
             send(
                 ManagementRequest::TableAdd(TableAdd {


### PR DESCRIPTION
Replaces the old zero-mask with a hardcoded slot count of `1` in `AddRoute4`. Added routes are now correctly read by scadm, and I assume that the slot count is no longer being read as zero. After applying this change, I'm able to access my local helios-hosted control plane again.

Closes #21.