### PR TITLE
Forward known Geneve options between underlay ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ checksum = "8200429754152e6379fbb1dd06eea90156c3b67591f6e31d08e787d010ef0168"
 [[package]]
 name = "p4"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=main#d12254ef4de50eece30e4906d83650b597f7f9e8"
+source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
 dependencies = [
  "colored",
  "regex",
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "p4-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=main#d12254ef4de50eece30e4906d83650b597f7f9e8"
+source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
 dependencies = [
  "p4",
  "p4-rust",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "p4-rust"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=main#d12254ef4de50eece30e4906d83650b597f7f9e8"
+source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
 dependencies = [
  "p4",
  "prettyplease",
@@ -1666,6 +1666,17 @@ dependencies = [
 name = "p4rs"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/p4?branch=main#d12254ef4de50eece30e4906d83650b597f7f9e8"
+dependencies = [
+ "bitvec",
+ "num",
+ "serde",
+ "usdt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "p4rs"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
 dependencies = [
  "bitvec",
  "num",
@@ -2242,7 +2253,7 @@ dependencies = [
  "libc",
  "macaddr",
  "num",
- "p4rs",
+ "p4rs 0.1.0 (git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction)",
  "serde",
  "serde_json",
  "softnpu",
@@ -2462,7 +2473,7 @@ dependencies = [
  "colored",
  "num",
  "p4-macro",
- "p4rs",
+ "p4rs 0.1.0 (git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction)",
  "pnet",
  "pnet_macros",
  "pnet_macros_support",
@@ -2617,7 +2628,7 @@ name = "softnpu"
 version = "0.2.0"
 source = "git+https://github.com/oxidecomputer/softnpu?branch=main#e19b7fa203a35e4084cd04604fd47ba626c0d33b"
 dependencies = [
- "p4rs",
+ "p4rs 0.1.0 (git+https://github.com/oxidecomputer/p4?branch=main)",
  "serde",
  "serde_json",
  "tokio",
@@ -2766,14 +2777,14 @@ dependencies = [
 [[package]]
 name = "tests"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=main#d12254ef4de50eece30e4906d83650b597f7f9e8"
+source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
 dependencies = [
  "anyhow",
  "bitvec",
  "colored",
  "num",
  "p4-macro",
- "p4rs",
+ "p4rs 0.1.0 (git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction)",
  "pnet",
  "rand",
  "usdt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ checksum = "8200429754152e6379fbb1dd06eea90156c3b67591f6e31d08e787d010ef0168"
 [[package]]
 name = "p4"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#ae7f336b2f3f8b29f66d723094dbb2a94fb20e81"
 dependencies = [
  "colored",
  "regex",
@@ -1639,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "p4-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#ae7f336b2f3f8b29f66d723094dbb2a94fb20e81"
 dependencies = [
  "p4",
  "p4-rust",
@@ -1652,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "p4-rust"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#ae7f336b2f3f8b29f66d723094dbb2a94fb20e81"
 dependencies = [
  "p4",
  "prettyplease",
@@ -1666,17 +1666,6 @@ dependencies = [
 name = "p4rs"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/p4?branch=main#d12254ef4de50eece30e4906d83650b597f7f9e8"
-dependencies = [
- "bitvec",
- "num",
- "serde",
- "usdt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "p4rs"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
 dependencies = [
  "bitvec",
  "num",
@@ -2253,7 +2242,7 @@ dependencies = [
  "libc",
  "macaddr",
  "num",
- "p4rs 0.1.0 (git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction)",
+ "p4rs",
  "serde",
  "serde_json",
  "softnpu",
@@ -2473,7 +2462,7 @@ dependencies = [
  "colored",
  "num",
  "p4-macro",
- "p4rs 0.1.0 (git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction)",
+ "p4rs",
  "pnet",
  "pnet_macros",
  "pnet_macros_support",
@@ -2628,7 +2617,7 @@ name = "softnpu"
 version = "0.2.0"
 source = "git+https://github.com/oxidecomputer/softnpu?branch=main#e19b7fa203a35e4084cd04604fd47ba626c0d33b"
 dependencies = [
- "p4rs 0.1.0 (git+https://github.com/oxidecomputer/p4?branch=main)",
+ "p4rs",
  "serde",
  "serde_json",
  "tokio",
@@ -2777,14 +2766,14 @@ dependencies = [
 [[package]]
 name = "tests"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction#b522c6fa82e5dc0b815790a8d198b957bafefeb2"
+source = "git+https://github.com/oxidecomputer/p4?branch=main#ae7f336b2f3f8b29f66d723094dbb2a94fb20e81"
 dependencies = [
  "anyhow",
  "bitvec",
  "colored",
  "num",
  "p4-macro",
- "p4rs 0.1.0 (git+https://github.com/oxidecomputer/p4?branch=ry%2Fsubtraction)",
+ "p4rs",
  "pnet",
  "rand",
  "usdt 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-p4rs = { git = "https://github.com/oxidecomputer/p4", branch = "main" }
-p4-macro = { git = "https://github.com/oxidecomputer/p4", branch = "main" }
-p4-test = { package = "tests", git = "https://github.com/oxidecomputer/p4", branch = "main" }
+p4rs = { git = "https://github.com/oxidecomputer/p4", branch = "ry/subtraction" }
+p4-macro = { git = "https://github.com/oxidecomputer/p4", branch = "ry/subtraction" }
+p4-test = { package = "tests", git = "https://github.com/oxidecomputer/p4", branch = "ry/subtraction" }
 usdt = { git = "https://github.com/oxidecomputer/usdt" }
 
 base64 = { version = "0.22" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-p4rs = { git = "https://github.com/oxidecomputer/p4", branch = "ry/subtraction" }
-p4-macro = { git = "https://github.com/oxidecomputer/p4", branch = "ry/subtraction" }
-p4-test = { package = "tests", git = "https://github.com/oxidecomputer/p4", branch = "ry/subtraction" }
+p4rs = { git = "https://github.com/oxidecomputer/p4", branch = "main" }
+p4-macro = { git = "https://github.com/oxidecomputer/p4", branch = "main" }
+p4-test = { package = "tests", git = "https://github.com/oxidecomputer/p4", branch = "main" }
 usdt = { git = "https://github.com/oxidecomputer/usdt" }
 
 base64 = { version = "0.22" }

--- a/p4/headers.p4
+++ b/p4/headers.p4
@@ -165,11 +165,16 @@ struct headers_t {
     tcp_h tcp;
     udp_h udp;
 
-    // As above, x4c does not support header stacks. We're assuming that OPTE
-    // and SoftNPU will, for now, push at most one option. Sidecar also makes
-    // the same assumption.
     geneve_h geneve;
 
+    // As above, x4c does not support header stacks. We do need to inspect
+    // some headers (e.g., oxg_mcast) to determine correct forwarding
+    // behaviour for multicast traffic, which means that at least some
+    // headers must be well-typed. The construction here provides this, but
+    // allows for at most one of each option. If/when we need passthrough for
+    // arbitrary-sized options, we can do so using a similar design as above
+    // (although g_tag_0, g_chunk_0_0, g_chunk_0_1, g_chunk_0_2, ... would not
+    // be pretty).
     geneve_opt_h oxg_external_tag;
     geneve_opt_h oxg_mcast_tag;
     oxg_opt_multicast_h oxg_mcast;

--- a/p4/headers.p4
+++ b/p4/headers.p4
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 header sidecar_h {
     bit<8> sc_code;
@@ -95,6 +95,15 @@ header geneve_opt_h {
     bit<5> opt_len;
 }
 
+header oxg_opt_multicast_h {
+    bit<2> replication;
+    bit<30> reserved;
+}
+
+header oxg_opt_mss_h {
+    bit<32> mss;
+}
+
 header arp_h {
 	bit<16>		hw_type;
 	bit<16>		proto_type;
@@ -156,8 +165,14 @@ struct headers_t {
     tcp_h tcp;
     udp_h udp;
 
+    // As above, x4c does not support header stacks. We're assuming that OPTE
+    // and SoftNPU will, for now, push at most one option. Sidecar also makes
+    // the same assumption.
     geneve_h geneve;
-    geneve_opt_h    ox_external_tag;
+    geneve_opt_h ox_opt_tag;
+    oxg_opt_multicast_h ox_mcast_body;
+    oxg_opt_mss_h ox_mss_body;
+
     ethernet_h inner_eth;
     ipv4_h inner_ipv4;
     ipv6_h inner_ipv6;

--- a/p4/headers.p4
+++ b/p4/headers.p4
@@ -169,9 +169,12 @@ struct headers_t {
     // and SoftNPU will, for now, push at most one option. Sidecar also makes
     // the same assumption.
     geneve_h geneve;
-    geneve_opt_h ox_opt_tag;
-    oxg_opt_multicast_h ox_mcast_body;
-    oxg_opt_mss_h ox_mss_body;
+
+    geneve_opt_h oxg_external_tag;
+    geneve_opt_h oxg_mcast_tag;
+    oxg_opt_multicast_h oxg_mcast;
+    geneve_opt_h oxg_mss_tag;
+    oxg_opt_mss_h oxg_mss;
 
     ethernet_h inner_eth;
     ipv4_h inner_ipv4;

--- a/p4/sidecar-lite.p4
+++ b/p4/sidecar-lite.p4
@@ -69,9 +69,11 @@ control ingress(
 
     action decap_geneve() {
         hdr.geneve.setInvalid();
-        hdr.ox_opt_tag.setInvalid();
-        hdr.ox_mcast_body.setInvalid();
-        hdr.ox_mss_body.setInvalid();
+        hdr.oxg_external_tag.setInvalid();
+        hdr.oxg_mcast_tag.setInvalid();
+        hdr.oxg_mcast.setInvalid();
+        hdr.oxg_mss_tag.setInvalid();
+        hdr.oxg_mss.setInvalid();
         hdr.ethernet = hdr.inner_eth;
         hdr.inner_eth.setInvalid();
         if (hdr.inner_ipv4.isValid()) {
@@ -239,12 +241,12 @@ control nat_ingress(
 
         // 4-byte option -- 'VPC-external packet'.
         // XXX: const GENEVE_OPT_CLASS_OXIDE not recognised here by x4c.
-        hdr.ox_opt_tag.class = 16w0x0129;
-        hdr.ox_opt_tag.crit = 1w0;
-        hdr.ox_opt_tag.rtype = 7w0x00;
-        hdr.ox_opt_tag.reserved = 3w0;
-        hdr.ox_opt_tag.opt_len = 5w0;
-        hdr.ox_opt_tag.setValid();
+        hdr.oxg_external_tag.class = 16w0x0129;
+        hdr.oxg_external_tag.crit = 1w0;
+        hdr.oxg_external_tag.rtype = 7w0x00;
+        hdr.oxg_external_tag.reserved = 3w0;
+        hdr.oxg_external_tag.opt_len = 5w0;
+        hdr.oxg_external_tag.setValid();
 
         /// TODO: this is broken so just set to zero for now.
         hdr.udp.checksum = csum.run({
@@ -259,7 +261,7 @@ control nat_ingress(
             hdr.geneve.protocol,
             hdr.geneve.vni,
             8w0x00,
-            hdr.ox_opt_tag.class,
+            hdr.oxg_external_tag.class,
             orig_l3_csum,
         });
         hdr.udp.checksum = 16w0;

--- a/p4/sidecar-lite.p4
+++ b/p4/sidecar-lite.p4
@@ -69,6 +69,9 @@ control ingress(
 
     action decap_geneve() {
         hdr.geneve.setInvalid();
+        hdr.ox_opt_tag.setInvalid();
+        hdr.ox_mcast_body.setInvalid();
+        hdr.ox_mss_body.setInvalid();
         hdr.ethernet = hdr.inner_eth;
         hdr.inner_eth.setInvalid();
         if (hdr.inner_ipv4.isValid()) {
@@ -236,12 +239,12 @@ control nat_ingress(
 
         // 4-byte option -- 'VPC-external packet'.
         // XXX: const GENEVE_OPT_CLASS_OXIDE not recognised here by x4c.
-        hdr.ox_external_tag.class = 16w0x0129;
-        hdr.ox_external_tag.crit = 1w0;
-        hdr.ox_external_tag.rtype = 7w0x00;
-        hdr.ox_external_tag.reserved = 3w0;
-        hdr.ox_external_tag.opt_len = 5w0;
-        hdr.ox_external_tag.setValid();
+        hdr.ox_opt_tag.class = 16w0x0129;
+        hdr.ox_opt_tag.crit = 1w0;
+        hdr.ox_opt_tag.rtype = 7w0x00;
+        hdr.ox_opt_tag.reserved = 3w0;
+        hdr.ox_opt_tag.opt_len = 5w0;
+        hdr.ox_opt_tag.setValid();
 
         /// TODO: this is broken so just set to zero for now.
         hdr.udp.checksum = csum.run({
@@ -256,7 +259,7 @@ control nat_ingress(
             hdr.geneve.protocol,
             hdr.geneve.vni,
             8w0x00,
-            hdr.ox_external_tag.class,
+            hdr.ox_opt_tag.class,
             orig_l3_csum,
         });
         hdr.udp.checksum = 16w0;

--- a/p4/softnpu.p4
+++ b/p4/softnpu.p4
@@ -1,11 +1,17 @@
 // Copyright 2022 Oxide Computer Company
 
+#include <headers.p4>
+
 struct ingress_metadata_t {
     bit<16> port;
     bit<16> nat_id;
     bit<16> path_idx;
     bool nat;
     bool lldp;
+
+    // Used as mutable scratchpad shared between parser states.
+    bit<6> geneve_chunks;
+    geneve_opt_h curr_opt;
 }
 
 struct egress_metadata_t {


### PR DESCRIPTION
This PR teaches sidecar-lite how to parse two new Oxide-specific geneve options:
* The multicast information option ([source in sidecar](https://github.com/oxidecomputer/dendrite/blob/4c6f4b8443e2394669eb6200a9e8e881f67740fd/dpd/p4/headers.p4#L171-L184)).
* The MSS option, used in https://github.com/oxidecomputer/opte/pull/805.

It doesn't do anything with these other than forward them. We're still making the assumption that we only have one option in use at any given time. I attempted to work around this by counting the remaining 4B chunks in `struct ingress_metadata_t`, but I don't think we can perform arithmetic in parsers with x4c yet (e.g., `ingress.geneve_chunks = ingress.geneve_chunks - 6w1;` seemed to be missing some trait impls when compiling the crate).